### PR TITLE
ignore script tags without src attribute

### DIFF
--- a/lib/replace.js
+++ b/lib/replace.js
@@ -24,7 +24,7 @@ module.exports = function (htmlToReplace, options, logger) {
   // Find <link> and <scripts>
   var nodes = [];
   nodes = nodes.concat(xpath.select("//link[not(contains(@href, '//'))]", dom));
-  nodes = nodes.concat(xpath.select("//script[not(contains(@src, '//'))]", dom));
+  nodes = nodes.concat(xpath.select("//script[@src and not(contains(@src, '//'))]", dom));
   logger('Statics found: ' + nodes.length + '\n');
 
   nodes.forEach(function (value) {

--- a/test/bridge_test.js
+++ b/test/bridge_test.js
@@ -65,5 +65,20 @@ exports.bridge = {
     test.equal(actual, expected, 'should use a different pattern');
 
     test.done();
+  },
+  scriptNoSrc: function(test) {
+    test.expect(1);
+
+    var options = {
+      html: 'test/fixtures/scriptnosrc.html',
+      pattern: '{{# url \'{path}\' }}',
+      dest: 'tmp/scriptnosrc.html'
+    };
+
+    var actual = bridgeReplacement(grunt.file.read('test/fixtures/scriptnosrc.html'), options);
+    var expected = grunt.file.read('test/expected/scriptnosrc.html');
+    test.equal(actual, expected, 'should use a different pattern');
+
+    test.done();
   }
 };

--- a/test/expected/scriptnosrc.html
+++ b/test/expected/scriptnosrc.html
@@ -1,0 +1,20 @@
+{% load staticfiles %}
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="">
+    <meta name="author" content="">
+
+    <title>Bootstrap</title>
+
+</head>
+<body>
+    <script>
+        console.log('hello');
+    </script>
+</body>
+</html>

--- a/test/fixtures/scriptnosrc.html
+++ b/test/fixtures/scriptnosrc.html
@@ -1,0 +1,20 @@
+{% load staticfiles %}
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="">
+    <meta name="author" content="">
+
+    <title>Bootstrap</title>
+
+</head>
+<body>
+    <script>
+        console.log('hello');
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Script tags without a src attribute should be ignored.
I had a problem with the index.html file from yeoman generator-webapp. It contains a script tag with google analytics code.
